### PR TITLE
add session-expired and fix 404 Page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -8,6 +8,7 @@ import UserPage from './pages/UserPage/UserPage';
 import UserPageLayout from './pages/UserPage/UserPageLayout';
 import CategoriesPage from './pages/CategoriesPage/CategoriesPage';
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage';
+import SessionExpiredPage from './pages/SessionExpiredPage';
 
 export default function AppRouter() {
   return (
@@ -27,6 +28,7 @@ export default function AppRouter() {
           </Route>
           <Route path="categories" element={<CategoriesPage />} />
           <Route path="categories/:id" element={<CategoriesPage />} />
+          <Route path="session-expired" element={<SessionExpiredPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -5,16 +5,16 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { ROUTERS } from '../const';
 import { selectIsLoggedIn } from '../redux/auth/selectors';
 
-const PrivateRoute = ({ component: Component, redirectTo = ROUTERS.HOME }) => {
+const PrivateRoute = ({ component: Component }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const isLoggedIn = useSelector(selectIsLoggedIn);
 
   useEffect(() => {
     if (!isLoggedIn) {
-      navigate(redirectTo, { state: location });
+      navigate('/session-expired', { state: location });
     }
-  }, [redirectTo, isLoggedIn, location, navigate]);
+  }, [isLoggedIn, location, navigate]);
 
   return Component;
 };

--- a/src/pages/SessionExpiredPage.jsx
+++ b/src/pages/SessionExpiredPage.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { showModal } from '../redux/common/slice';
+import { MODALS } from '../const';
+
+const SessionExpiredPage = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(showModal(MODALS.SIGN_IN));
+  }, [dispatch]);
+
+  const handleLoginClick = () => {
+    dispatch(showModal(MODALS.SIGN_IN));
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <h1>Session Expired</h1>
+      <p>
+        Your session has expired or you have been logged out. Please log in
+        again to continue.
+      </p>
+      <button
+        onClick={handleLoginClick}
+        style={{
+          marginTop: 24,
+          padding: '10px 24px',
+          fontSize: 16,
+          cursor: 'pointer',
+        }}
+      >
+        Log In
+      </button>
+    </div>
+  );
+};
+
+export default SessionExpiredPage;


### PR DESCRIPTION
Якщо користувач не залогінений (наприклад, токен видалився або сесія завершилась), при спробі зайти на захищену сторінку його буде редіректити на /session-expired.
На сторінці "Session Expired" є кнопка для відкриття модалки логіну.
404 сторінка працює для всіх неіснуючих маршрутів, як і раніше.
Також модалка логіну буде автоматично відкриватися при завантаженні сторінки SessionExpiredPage. Кнопка "Log In" також залишилася для повторного відкриття модалки, якщо користувач її закриє.
